### PR TITLE
Fix comparison of uneven release part

### DIFF
--- a/cmp_version/__init__.py
+++ b/cmp_version/__init__.py
@@ -212,10 +212,12 @@ def _cmp_version_internal(version1, version2, versionIdxNum=0):
                 (alpha1, numeric1) = try1[j]
                 (alpha2, numeric2) = try2[j]
 
-                resAlpha = cmp(alpha1.lower(), alpha2.lower())
-                if resAlpha != 0:
-                    # Alpha blocks are not the same, we are done.
-                    return resAlpha
+                # Some of alpha is empty string, so don't compare them
+                if alpha1 and alpha2:
+                    resAlpha = cmp(alpha1.lower(), alpha2.lower())
+                    if resAlpha != 0:
+                        # Alpha blocks are not the same, we are done.
+                        return resAlpha
 
                 # Alpha are same or empty, so compare digits
                 resNumeric = 0
@@ -227,12 +229,12 @@ def _cmp_version_internal(version1, version2, versionIdxNum=0):
                             # Difference in numbers, return cmp result.
                             return resNumeric
                     else:
-                        # Only digits in version1's block, thus it is greater
+                        # Only digits in version1's block, thus version1 is greater
                         return 1
                 else:
                     if numeric2:
-                        # Only digits in version2's block, thus it is greater
-                        return 1
+                        # Only digits in version2's block, thus version1 is smaller
+                        return -1
 
             if try2Len > try1Len:
                 # All in version1's block match version2's block

--- a/tests/cmp_version_Tests/test_Release.py
+++ b/tests/cmp_version_Tests/test_Release.py
@@ -80,6 +80,7 @@ class TestRelease(object):
         assert cmpFunc('1.0-2.0-3.0', '1.0-2.0') > 0 , 'Expected "1.0-2.0-3.0" to be greater than "1.0-2.0"'
         assert cmpFunc('1.0-2.0', '1.0-2.0-3.0') < 0 , 'Expected "1.0-2.0" to be less than "1.0-2.0-3.0"'
         assert cmpFunc('1.0-2.0', '1.0-2.0-0-0-0') == 0 , 'Expected "1.0-2.0" to be equal to "1.0-2.0-0-0-0"'
+        assert cmpFunc('1.0-1.el7_6', '1.0-1.1.el7_6') < 0, 'Expected "1.0-1.el7_6" to be less than "1.0-1.1.el7_6"'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fixes wrong comparison between uneven release string.
E.g. 1.0-1.el7_6' and '1.0-1.1.el7_6'.

Fixes #1 